### PR TITLE
Relax parsing rules for group/artifact IDs

### DIFF
--- a/dola-dbs/src/main/java/io/kojan/dola/build/parser/BuildOptionParser.java
+++ b/dola-dbs/src/main/java/io/kojan/dola/build/parser/BuildOptionParser.java
@@ -112,18 +112,11 @@ public class BuildOptionParser {
         StringBuilder sb = new StringBuilder();
         while (pos < str.length()) {
             char ch = str.charAt(pos);
-            if ((ch >= 'a' && ch <= 'z')
-                    || (ch >= 'A' && ch <= 'Z')
-                    || (ch >= '0' && ch <= '9')
-                    || ch == '-'
-                    || ch == '.'
-                    || ch == '/'
-                    || ch == '_') {
-                sb.append(ch);
-                pos++;
-            } else {
+            if (ch == ':' || ch == '@' || ch == '|' || ch == '>' || ch == ';') {
                 break;
             }
+            sb.append(ch);
+            pos++;
         }
         return sb.toString();
     }


### PR DESCRIPTION
Previously, only a limited set of allowed characters could be used in group and artifact IDs. This commit changes the approach to reject invalid characters instead, making the parsing more flexible and reducing false negatives.