### PR TITLE
Switch to new declarative syntax

### DIFF
--- a/dola-dbs/src/main/java/io/kojan/dola/build/TransformOption.java
+++ b/dola-dbs/src/main/java/io/kojan/dola/build/TransformOption.java
@@ -19,10 +19,36 @@ public class TransformOption {
 
     private final String opcode;
     private final String argument;
+    private final String selector;
 
-    public TransformOption(String opcode, String argument) {
+    public static TransformOption ofRemoveParent(String selector) {
+        return new TransformOption("removeParent", ":", selector);
+    }
+
+    public static TransformOption ofRemoveParent(String matcher, String selector) {
+        return new TransformOption("removeParent", matcher, selector);
+    }
+
+    public static TransformOption ofRemovePlugin(String matcher, String selector) {
+        return new TransformOption("removePlugin", matcher, selector);
+    }
+
+    public static TransformOption ofRemoveDependency(String matcher, String selector) {
+        return new TransformOption("removeDependency", matcher, selector);
+    }
+
+    public static TransformOption ofRemoveSubproject(String matcher, String selector) {
+        return new TransformOption("removeSubproject", matcher, selector);
+    }
+
+    public static TransformOption ofAddDependency(String matcher, String selector) {
+        return new TransformOption("addDependency", matcher, selector);
+    }
+
+    private TransformOption(String opcode, String argument, String selector) {
         this.opcode = opcode;
         this.argument = argument;
+        this.selector = selector;
     }
 
     public String getOpcode() {
@@ -31,5 +57,9 @@ public class TransformOption {
 
     public String getArgument() {
         return argument;
+    }
+
+    public String getSelector() {
+        return selector;
     }
 }

--- a/dola-dbs/src/main/java/io/kojan/dola/build/parser/Lexer.java
+++ b/dola-dbs/src/main/java/io/kojan/dola/build/parser/Lexer.java
@@ -1,0 +1,142 @@
+/*-
+ * Copyright (c) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kojan.dola.build.parser;
+
+class Lexer {
+    final String str;
+    final int eoi;
+    int lexBeg;
+    int lexEnd;
+    int pos;
+
+    public Lexer(String str) {
+        this.str = str + '$';
+        eoi = str.length();
+        // Reject TABs upfront so that we don't need to care about them in the parser code
+        if (str.indexOf('\t') >= 0) {
+            pos = str.indexOf('\t');
+            error("Lexical error: TAB characters are not allowed, replace them with spaces");
+        }
+        lookahead();
+    }
+
+    public Error error(String msg) {
+        // Count lines
+        int lineStart = 0;
+        int lineNumber = 1;
+        for (int i = 0; i < lexBeg; i++) {
+            if (str.charAt(i) == '\n') {
+                lineStart = i + 1;
+                lineNumber++;
+            }
+        }
+        int lineEnd = eoi;
+        for (int i = lexBeg; i < eoi; i++) {
+            if (str.charAt(i) == '\n') {
+                lineEnd = i;
+                break;
+            }
+        }
+        String line = str.substring(lineStart, lineEnd);
+        String banner = "~".repeat(Math.max(10, lineEnd - lineStart));
+        StringBuilder sb = new StringBuilder();
+        sb.append(msg);
+        sb.append("\nat line ")
+                .append(lineNumber)
+                .append(":\n")
+                .append(banner)
+                .append("\n")
+                .append(line)
+                .append("\n")
+                .append(banner)
+                .append("\n");
+        if (lexBeg - lineStart >= 10) {
+            sb.append("  here ");
+            sb.append("-".repeat(lexBeg - lineStart - 7));
+            sb.append("^");
+        } else {
+            sb.append(" ".repeat(lexBeg - lineStart));
+            sb.append("^--- here");
+        }
+        throw new RuntimeException(sb.toString());
+    }
+
+    private void lookahead() {
+        int ch;
+        while ((ch = str.charAt(pos)) == ' ' || ch == '\n') {
+            pos++;
+        }
+    }
+
+    public Lexer next() {
+        lexBeg = pos;
+        if (pos == eoi) {
+            lexEnd = pos;
+            return this;
+        }
+        int ch = str.charAt(pos++);
+        if (ch == '"') {
+            while (str.charAt(pos++) != '"') {
+                if (pos > eoi) {
+                    error("Lexical error: unterminated string literal");
+                }
+            }
+        } else if (ch >= 'a' && ch <= 'z') {
+            while (((ch = str.charAt(pos)) >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {
+                pos++;
+            }
+        } else if (ch != '{' && ch != '}') {
+            error("Lexical error: illegal character");
+        }
+        lexEnd = pos;
+        lookahead();
+        return this;
+    }
+
+    public boolean isKeyword() {
+        int ch = str.charAt(lexBeg);
+        return ch >= 'a' && ch <= 'z';
+    }
+
+    public boolean isKeyword(String kw) {
+        return kw.length() == lexEnd - lexBeg && str.regionMatches(lexBeg, kw, 0, lexEnd - lexBeg);
+    }
+
+    public String expectLiteral() {
+        if (str.charAt(lexBeg) != '"') {
+            error("Syntax error: expected literal (quoted string)");
+        }
+        return str.substring(lexBeg + 1, lexEnd - 1);
+    }
+
+    public void expectBlockBegin() {
+        if (str.charAt(lexBeg) != '{') {
+            error("Syntax error: expected opening brace '{'");
+        }
+    }
+
+    public boolean isBlockEnd() {
+        return str.charAt(lexBeg) == '}';
+    }
+
+    public boolean isEndOfInput() {
+        return lexBeg == eoi;
+    }
+
+    public boolean lookaheadIsLiteral() {
+        return str.charAt(pos) == '"';
+    }
+}

--- a/dola-dbs/src/main/java/io/kojan/dola/dbs/DBS.java
+++ b/dola-dbs/src/main/java/io/kojan/dola/dbs/DBS.java
@@ -18,7 +18,6 @@ package io.kojan.dola.dbs;
 import static io.kojan.dola.rpm.RPM.rpmExpand;
 
 import io.kojan.dola.build.DeclarativeBuild;
-import io.kojan.dola.build.DeclarativeBuildBuilder;
 import io.kojan.dola.build.parser.BuildOptionParser;
 import io.kojan.dola.imperator.Imperator;
 import java.util.stream.Collectors;
@@ -40,14 +39,13 @@ public class DBS {
 
     public static String conf() throws Exception {
         String rpmName = rpmExpand("%{name}");
-        DeclarativeBuildBuilder ctxBuilder = new DeclarativeBuildBuilder(rpmName);
+        StringBuilder dslBuilder = new StringBuilder();
         int n = Integer.parseInt(rpmExpand("%#"));
         for (int i = 2; i <= n; i++) {
-            String x = rpmExpand("%" + i);
-            BuildOptionParser parser = new BuildOptionParser(x, ctxBuilder);
-            parser.parse();
+            dslBuilder.append(rpmExpand("%" + i)).append('\n');
         }
-        DeclarativeBuild ctx = ctxBuilder.build();
+        BuildOptionParser parser = new BuildOptionParser(rpmName, dslBuilder.toString());
+        DeclarativeBuild ctx = parser.parse();
 
         boolean withBootstrap = !rpmExpand("%{with bootstrap}").equals("0");
 

--- a/dola-dbs/src/main/java/io/kojan/dola/imperator/Imperator.java
+++ b/dola-dbs/src/main/java/io/kojan/dola/imperator/Imperator.java
@@ -43,7 +43,7 @@ public class Imperator {
         for (var t : ctx.getTransformOptions()) {
             String id = String.format("%03d", i++);
             String key = "dola.transformer.insn." + id + "." + t.getOpcode();
-            String val = t.getArgument();
+            String val = t.getArgument() + "@" + t.getSelector();
             args.add("-D" + key + "=" + val);
         }
         return args;

--- a/dola-dbs/src/test/java/io/kojan/dola/build/parser/BuildOptionParserTest.java
+++ b/dola-dbs/src/test/java/io/kojan/dola/build/parser/BuildOptionParserTest.java
@@ -16,107 +16,799 @@
 package io.kojan.dola.build.parser;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import io.kojan.dola.build.Alias;
 import io.kojan.dola.build.DeclarativeBuild;
-import io.kojan.dola.build.DeclarativeBuildBuilder;
-import io.kojan.dola.build.PackagingOption;
+import org.fedoraproject.xmvn.artifact.Artifact;
 import org.junit.jupiter.api.Test;
 
 class BuildOptionParserTest {
 
-    private DeclarativeBuild c;
-    private PackagingOption r;
+    DeclarativeBuild parse(String s) {
+        return new BuildOptionParser("mypkg", s.replace('\n', ' ')).parse();
+    }
 
-    private void parse(String s) {
-        DeclarativeBuildBuilder cb = new DeclarativeBuildBuilder("mypkg");
-        BuildOptionParser p = new BuildOptionParser(s, cb);
-        p.parse();
-        c = cb.build();
-        assertThat(c.getPackagingOptions().size()).isEqualTo(1);
-        r = c.getPackagingOptions().getFirst();
+    DeclarativeBuild parsed(String s) {
+        DeclarativeBuild db = parse(s);
+        assertThat(db).isNotNull();
+        return db;
     }
 
     @Test
-    void file() {
-        parse("=gid:aid>foo/bar");
-        assertThat(r.getGroupIdGlob()).isEqualTo("gid");
-        assertThat(r.getArtifactIdGlob()).isEqualTo("aid");
-        assertThat(r.getExtensionGlob()).isEqualTo("");
-        assertThat(r.getClassifierGlob()).isEqualTo("");
-        assertThat(r.getVersionGlob()).isEqualTo("");
-        assertThat(r.getTargetPackage()).isEqualTo("");
-        assertThat(r.getAliases().size()).isEqualTo(0);
-        assertThat(r.getCompatVersions().size()).isEqualTo(0);
-        assertThat(r.getFiles().size()).isEqualTo(1);
-        assertThat(r.getFiles().getFirst()).isEqualTo("foo/bar");
+    void empty() {
+        parsed("");
     }
 
     @Test
-    void testPackage() {
-        parse("=gid:aid@pkgg1");
-        assertThat(r.getGroupIdGlob()).isEqualTo("gid");
-        assertThat(r.getArtifactIdGlob()).isEqualTo("aid");
-        assertThat(r.getExtensionGlob()).isEqualTo("");
-        assertThat(r.getClassifierGlob()).isEqualTo("");
-        assertThat(r.getVersionGlob()).isEqualTo("");
-        assertThat(r.getTargetPackage()).isEqualTo("pkgg1");
-        assertThat(r.getAliases().size()).isEqualTo(0);
-        assertThat(r.getCompatVersions().size()).isEqualTo(0);
-        assertThat(r.getFiles().size()).isEqualTo(0);
+    void whitespaceOnly() {
+        parsed("  ");
     }
 
     @Test
-    void alias() {
-        parse("=gid:aid|ag:aa");
-        assertThat(r.getGroupIdGlob()).isEqualTo("gid");
-        assertThat(r.getArtifactIdGlob()).isEqualTo("aid");
-        assertThat(r.getExtensionGlob()).isEqualTo("");
-        assertThat(r.getClassifierGlob()).isEqualTo("");
-        assertThat(r.getVersionGlob()).isEqualTo("");
-        assertThat(r.getTargetPackage()).isEqualTo("");
-        assertThat(r.getAliases().size()).isEqualTo(1);
-        assertThat(r.getAliases().getFirst().getGroupId()).isEqualTo("ag");
-        assertThat(r.getAliases().getFirst().getArtifactId()).isEqualTo("aa");
-        assertThat(r.getAliases().getFirst().getExtension()).isEqualTo("");
-        assertThat(r.getAliases().getFirst().getClassifier()).isEqualTo("");
-        assertThat(r.getCompatVersions().size()).isEqualTo(0);
-        assertThat(r.getFiles().size()).isEqualTo(0);
+    void lexicalError() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parse("skipTests%bar"))
+                .withMessageContaining("Lexical error");
     }
 
     @Test
-    void version() {
-        parse("=gid:aid;42");
-        assertThat(r.getGroupIdGlob()).isEqualTo("gid");
-        assertThat(r.getArtifactIdGlob()).isEqualTo("aid");
-        assertThat(r.getExtensionGlob()).isEqualTo("");
-        assertThat(r.getClassifierGlob()).isEqualTo("");
-        assertThat(r.getVersionGlob()).isEqualTo("");
-        assertThat(r.getTargetPackage()).isEqualTo("");
-        assertThat(r.getAliases().size()).isEqualTo(0);
-        assertThat(r.getCompatVersions().size()).isEqualTo(1);
-        assertThat(r.getCompatVersions().getFirst()).isEqualTo("42");
-        assertThat(r.getFiles().size()).isEqualTo(0);
+    void capitalKeyword() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parse("SkipTests"))
+                .withMessageContaining("Lexical error");
+    }
+
+    @Test
+    void alphanumericKeyword() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parse("skipTests2"))
+                .withMessageContaining("Lexical error");
+    }
+
+    @Test
+    void keywordTypo() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parse("skipTestsss"))
+                .withMessageContaining("unrecognized keyword");
+    }
+
+    @Test
+    void transformBlockEmpty() {
+        String code =
+                """
+                    transform "foo:bar" {
+                    }
+                """;
+        parsed(code);
+    }
+
+    @Test
+    void skipTests() {
+        String code =
+                """
+                    skipTests
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.isSkipTests()).isTrue();
+    }
+
+    @Test
+    void singletonPackaging() {
+        String code =
+                """
+                    singletonPackaging
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.isSingletonPackaging()).isTrue();
+    }
+
+    @Test
+    void usesJavapackagesBootstrap() {
+        String code =
+                """
+                    usesJavapackagesBootstrap
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.usesJavapackagesBootstrap()).isTrue();
+    }
+
+    @Test
+    void mavenOption() {
+        String code =
+                """
+                    mavenOption "-Prun-its"
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getMavenOptions()).containsExactly("-Prun-its");
+    }
+
+    @Test
+    void mavenOptions() {
+        String code =
+                """
+                    mavenOptions {
+                        "-X"
+                        "-Dfoo=bar"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getMavenOptions()).containsExactly("-X", "-Dfoo=bar");
+    }
+
+    @Test
+    void buildRequire() {
+        String code =
+                """
+                    buildRequire "foo:bar"
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getExtraBuildReqs()).containsExactlyInAnyOrder(Artifact.of("foo:bar"));
+        assertThat(db.getFilteredBuildReqs()).isEmpty();
+    }
+
+    @Test
+    void buildRequireFilter() {
+        String code =
+                """
+                    buildRequireFilter "foo:bar"
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getExtraBuildReqs()).isEmpty();
+        assertThat(db.getFilteredBuildReqs()).containsExactlyInAnyOrder(Artifact.of("foo:bar"));
+    }
+
+    @Test
+    void buildRequiresOne() {
+        String code =
+                """
+                    buildRequires {
+                        "foo:bar"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getExtraBuildReqs()).containsExactlyInAnyOrder(Artifact.of("foo:bar"));
+        assertThat(db.getFilteredBuildReqs()).isEmpty();
+    }
+
+    @Test
+    void buildRequiresTwo() {
+        String code =
+                """
+                    buildRequires {
+                        "foo:bar"
+                        "com.example:eee:2.5"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getExtraBuildReqs())
+                .containsExactlyInAnyOrder(
+                        Artifact.of("foo:bar"), Artifact.of("com.example:eee:2.5"));
+        assertThat(db.getFilteredBuildReqs()).isEmpty();
+    }
+
+    @Test
+    void buildRequiresFilter() {
+        String code =
+                """
+                    buildRequires {
+                        "foo:bar"
+                        filter "*:baz"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getExtraBuildReqs()).containsExactlyInAnyOrder(Artifact.of("foo:bar"));
+        assertThat(db.getFilteredBuildReqs()).containsExactlyInAnyOrder(Artifact.of("*:baz"));
+    }
+
+    @Test
+    void testExclude() {
+        String code =
+                """
+                    testExclude "BadTest"
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTestExcludes()).containsExactly("BadTest");
+    }
+
+    @Test
+    void testExcludesOne() {
+        String code =
+                """
+                    testExcludes {
+                        "BadTest"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTestExcludes()).containsExactly("BadTest");
+    }
+
+    @Test
+    void testExcludesThree() {
+        String code =
+                """
+                    testExcludes {
+                        "BadTest"
+                        "AnotherBadOne"
+                        "YetAnother"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTestExcludes()).containsExactly("BadTest", "AnotherBadOne", "YetAnother");
+    }
+
+    @Test
+    void artifactEmpty() {
+        String code =
+                """
+                    artifact "some:thing" {}
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getGroupIdGlob()).isEqualTo("some");
+        assertThat(db.getPackagingOptions().getFirst().getArtifactIdGlob()).isEqualTo("thing");
+    }
+
+    @Test
+    void artifactPackage() {
+        String code =
+                """
+                    artifact "some:thing" {
+                        package "sub1"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getTargetPackage()).isEqualTo("sub1");
+    }
+
+    @Test
+    void artifactNoInstall() {
+        String code =
+                """
+                    artifact "some:thing" {noInstall}
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getTargetPackage()).isEqualTo("__noinstall");
+    }
+
+    @Test
+    void artifactRepository() {
+        String code =
+                """
+                    artifact "some:thing" {
+                        repository "my-repo"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getTargetRepository()).isEqualTo("my-repo");
+    }
+
+    @Test
+    void artifactFile() {
+        String code =
+                """
+                    artifact "some:thing" {
+                        file "foo/bar"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getFiles()).containsExactly("foo/bar");
+    }
+
+    @Test
+    void artifactFilesOne() {
+        String code =
+                """
+                    artifact "some:thing" {
+                        files { "foo/bar" }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getFiles()).containsExactly("foo/bar");
+    }
+
+    @Test
+    void artifactFilesThree() {
+        String code =
+                """
+                    artifact "some:thing" {
+                        files {
+                            "foo/bar"
+                            "baz" "xyzzy" }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getFiles())
+                .containsExactly("foo/bar", "baz", "xyzzy");
+    }
+
+    @Test
+    void artifactCompatVersion() {
+        String code =
+                """
+                    artifact "some:thing" {
+                        compatVersion "1.2.3"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getCompatVersions())
+                .containsExactly("1.2.3");
+    }
+
+    @Test
+    void artifactCompatVersionsOne() {
+        String code =
+                """
+                    artifact "some:thing" {
+                        compatVersions { "1.2.3" }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getCompatVersions())
+                .containsExactly("1.2.3");
+    }
+
+    @Test
+    void artifactCompatVersionsThree() {
+        String code =
+                """
+                    artifact "some:thing" {
+                        compatVersions {
+                            "1.2.3"
+                            "1.2.4"
+                            "1.0"
+                        }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getCompatVersions())
+                .containsExactly("1.2.3", "1.2.4", "1.0");
+    }
+
+    @Test
+    void artifactAlias() {
+        String code =
+                """
+                    artifact "some:thing" {
+                        alias ":aid-alias"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getAliases())
+                .containsExactly(Alias.of("", "aid-alias"));
+    }
+
+    @Test
+    void artifactAliasesOne() {
+        String code =
+                """
+                    artifact "some:thing" {
+                        aliases { ":aid-alias" }
+                    }
+                """;
+        DeclarativeBuild db = parse(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getAliases())
+                .containsExactly(Alias.of("", "aid-alias"));
+        assertThat(db).isNotNull();
+    }
+
+    @Test
+    void artifactAliasesThree() {
+        String code =
+                """
+                    artifact "some:thing" {
+                        aliases {
+                            ":aid-alias"
+                            "com.foo:my-art"
+                            "another:alias"
+                        }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions()).hasSize(1);
+        assertThat(db.getPackagingOptions().getFirst().getAliases())
+                .containsExactly(
+                        Alias.of("", "aid-alias"),
+                        Alias.of("com.foo", "my-art"),
+                        Alias.of("another", "alias"));
+    }
+
+    @Test
+    void transformEmpty() {
+        String code =
+                """
+                    transform "some:thing" {}
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(0);
+    }
+
+    @Test
+    void transformRemoveParentLone() {
+        String code =
+                """
+                    transform "some:thing" {
+                        removeParent
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(1);
+    }
+
+    @Test
+    void transformRemoveParentArg() {
+        String code =
+                """
+                    transform "some:thing" {
+                        removeParent "com.foo:my-parent"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(1);
+    }
+
+    @Test
+    void transformRemoveDependency() {
+        String code =
+                """
+                    transform "some:thing" {
+                        removeDependency ":foo"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(1);
+    }
+
+    @Test
+    void transformRemoveDependenciesOne() {
+        String code =
+                """
+                    transform "some:thing" {
+                        removeDependencies { "foo:bar" }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(1);
+    }
+
+    @Test
+    void transformRemoveDependenciesMultiple() {
+        String code =
+                """
+                    transform "some:thing" {
+                        removeDependencies {
+                            ":dep1"
+                            ":dep2"
+                            "biz.ness:proprietary-lib"
+                        }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(3);
+    }
+
+    @Test
+    void transformRemovePlugin() {
+        String code =
+                """
+                    transform "some:thing" {
+                        removePlugin ":maven-compiler-plugin"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(1);
+    }
+
+    @Test
+    void transformRemovePluginsOne() {
+        String code =
+                """
+                    transform "some:thing" {
+                        removePlugins {
+                            ":maven-compiler-plugin"
+                        }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(1);
+    }
+
+    @Test
+    void transformRemovePluginsThree() {
+        String code =
+                """
+                    transform "some:thing" {
+                        removePlugins {
+                            ":*rat*"
+                            ":*sonar*"
+                            ":exec-maven-plugin"
+                        }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(3);
+    }
+
+    @Test
+    void transformRemoveSubproject() {
+        String code =
+                """
+                    transform "some:thing" {
+                        removeSubproject "its"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(1);
+    }
+
+    @Test
+    void transformRemoveSubprojectsOne() {
+        String code =
+                """
+                    transform "some:thing" {
+                        removeSubprojects {
+                            "extensions"
+                        }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(1);
+    }
+
+    @Test
+    void transformRemoveSubprojectsThree() {
+        String code =
+                """
+                    transform "some:thing" {
+                        removeSubprojects {
+                            "spring"
+                            "mail"
+                            "integration-tests"
+                        }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(3);
+    }
+
+    @Test
+    void transformAddDependency() {
+        String code =
+                """
+                    transform "some:thing" {
+                        addDependency "junit:junit:4.12:test"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(1);
+    }
+
+    @Test
+    void transformAddDependenciesOne() {
+        String code =
+                """
+                    transform "some:thing" {
+                        addDependencies {
+                            "org.foo:dep1"
+                        }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(1);
+    }
+
+    @Test
+    void transformAddDependenciesThree() {
+        String code =
+                """
+                    transform "some:thing" {
+                        addDependencies {
+                            "org.foo:dep1"
+                            "org.foo:dep2"
+                            "org.foo:dep3"
+                        }
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(3);
+    }
+
+    @Test
+    void artifactBadKeyword() {
+        String code =
+                """
+                    artifact "some:thing" {
+                       boom
+                    }
+                """;
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> parse(code));
+    }
+
+    @Test
+    void transformBadKeyword() {
+        String code =
+                """
+                    transform "some:thing" {
+                        boom
+                    }
+                """;
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> parse(code));
+    }
+
+    @Test
+    void globalBadKeyword() {
+        String code =
+                """
+                    boom
+                """;
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> parse(code));
     }
 
     @Test
     void combined() {
-        parse("=gid:aid;1.2|:aa>file1>file2@pkg;3.4");
-        assertThat(r.getGroupIdGlob()).isEqualTo("gid");
-        assertThat(r.getArtifactIdGlob()).isEqualTo("aid");
-        assertThat(r.getExtensionGlob()).isEqualTo("");
-        assertThat(r.getClassifierGlob()).isEqualTo("");
-        assertThat(r.getVersionGlob()).isEqualTo("");
-        assertThat(r.getTargetPackage()).isEqualTo("pkg");
-        assertThat(r.getAliases().size()).isEqualTo(1);
-        assertThat(r.getAliases().getFirst().getGroupId()).isEqualTo("");
-        assertThat(r.getAliases().getFirst().getArtifactId()).isEqualTo("aa");
-        assertThat(r.getAliases().getFirst().getExtension()).isEqualTo("");
-        assertThat(r.getAliases().getFirst().getClassifier()).isEqualTo("");
-        assertThat(r.getCompatVersions().size()).isEqualTo(2);
-        assertThat(r.getCompatVersions().get(0)).isEqualTo("1.2");
-        assertThat(r.getCompatVersions().get(1)).isEqualTo("3.4");
-        assertThat(r.getFiles().size()).isEqualTo(2);
-        assertThat(r.getFiles().get(0)).isEqualTo("file1");
-        assertThat(r.getFiles().get(1)).isEqualTo("file2");
+        String code =
+                """
+                    usesJavapackagesBootstrap
+                    mavenOption "-DjavaVersion=8"
+                    mavenOptions {
+                        "-X"
+                        "-Prun-its"
+                    }
+                    testExclude "BadTest"
+                    testExcludes {
+                        "MyTest"
+                        "AnotherTest"
+                    }
+                    artifact "foo:bar" {
+                        aliases { ":other" }
+                        compatVersion "1.2.3"
+                        files {
+                          "foo/bar"
+                          "yyy"
+                        }
+                        package "my-subpackage"
+                    }
+                    artifact ":aggregator" {
+                        noInstall
+                    }
+                    transform "com.foo:*" {
+                        removeParent
+                        removeDependency ":foo"
+                        removeDependency ":junit"
+                        addDependency "com.bar:baz:1.2.3"
+                        addDependencies {
+                            "org.junit:junit:4.12:test"
+                            "org.easymock:easymock:4.3:test"
+                        }
+                    }
+                    transform "*:*" {
+                        removePlugins {
+                            ":first-bad-plugin"
+                            "biz.proprietary:another-bad-one"
+                        }
+                    }
+                """;
+        parsed(code);
+    }
+
+    @Test
+    void unclosedBraceShouldFail() {
+        String code = "artifact \"some:thing\" { package \"foo\"";
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parse(code))
+                .withMessageContaining("Syntax error");
+    }
+
+    @Test
+    void unclosedStringLiteralShouldFail() {
+        String code = "mavenOption \"-X";
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parse(code))
+                .withMessageContaining("Lexical error");
+    }
+
+    @Test
+    void duplicateKeywordInArtifactShouldFail() {
+        String code =
+                """
+                    artifact "com.foo:bar" {
+                        package "sub1"
+                        package "sub2"
+                    }
+                """;
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parse(code))
+                .withMessageContaining("duplicate target package");
+    }
+
+    @Test
+    void illegalKeywordInBlockShouldFail() {
+        String code =
+                """
+                    artifact "com.foo:bar" {
+                        unexpectedKeyword "value"
+                    }
+                """;
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parse(code))
+                .withMessageContaining("Syntax error");
+    }
+
+    @Test
+    void artifactWithInvalidAliasFormatShouldFail() {
+        String code =
+                """
+                    artifact "com.foo:bar" {
+                        alias "noColon"
+                    }
+                """;
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> parse(code))
+                .withMessageContaining("Syntax error");
+    }
+
+    @Test
+    void transformWithAllRemovals() {
+        String code =
+                """
+                    transform "group:artifact" {
+                        removeParent "some:parent"
+                        removePlugin ":plugin"
+                        removeDependency "dep:one"
+                        removeSubproject "sub"
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getTransformOptions()).hasSize(4);
+    }
+
+    @Test
+    void emptyBuildRequiresBlock() {
+        String code = "buildRequires {}";
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getExtraBuildReqs()).isEmpty();
+        assertThat(db.getFilteredBuildReqs()).isEmpty();
+    }
+
+    @Test
+    void emptyAliasesBlock() {
+        String code =
+                """
+                    artifact "x:y" {
+                        aliases {}
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions().getFirst().getAliases()).isEmpty();
+    }
+
+    @Test
+    void emptyFilesBlock() {
+        String code =
+                """
+                    artifact "x:y" {
+                        files {}
+                    }
+                """;
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getPackagingOptions().getFirst().getFiles()).isEmpty();
+    }
+
+    @Test
+    void whitespaceBetweenKeywordsAndLiterals() {
+        String code = "mavenOption    \"-X\"";
+        DeclarativeBuild db = parsed(code);
+        assertThat(db.getMavenOptions()).containsExactly("-X");
     }
 }

--- a/dola-dbs/src/test/java/io/kojan/dola/build/parser/LexerTest.java
+++ b/dola-dbs/src/test/java/io/kojan/dola/build/parser/LexerTest.java
@@ -1,0 +1,115 @@
+/*-
+ * Copyright (c) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kojan.dola.build.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.Test;
+
+class LexerTest {
+
+    @Test
+    void empty() {
+        Lexer lexer = new Lexer("");
+        assertThat(lexer.next().isEndOfInput()).isTrue();
+    }
+
+    @Test
+    void whitespaceOnly() {
+        Lexer lexer = new Lexer(" \n");
+        assertThat(lexer.next().isEndOfInput()).isTrue();
+    }
+
+    @Test
+    void keywordToken() {
+        Lexer lexer = new Lexer("print");
+        assertThat(lexer.next().isKeyword()).isTrue();
+        assertThat(lexer.isKeyword("print")).isTrue();
+        assertThat(lexer.next().isEndOfInput()).isTrue();
+    }
+
+    @Test
+    void literalToken() {
+        Lexer lexer = new Lexer("\"hello\"");
+        assertThat(lexer.next().expectLiteral()).isEqualTo("hello");
+        assertThat(lexer.next().isEndOfInput()).isTrue();
+    }
+
+    @Test
+    void beginToken() {
+        Lexer lexer = new Lexer("{");
+        lexer.next().expectBlockBegin();
+        assertThat(lexer.next().isEndOfInput()).isTrue();
+    }
+
+    @Test
+    void endToken() {
+        Lexer lexer = new Lexer("}");
+        assertThat(lexer.next().isBlockEnd()).isTrue();
+        assertThat(lexer.next().isEndOfInput()).isTrue();
+    }
+
+    @Test
+    void multipleTokens() {
+        Lexer lexer = new Lexer("print \"value\" { }");
+        assertThat(lexer.next().isKeyword("print")).isTrue();
+        assertThat(lexer.next().expectLiteral()).isEqualTo("value");
+        lexer.next().expectBlockBegin();
+        assertThat(lexer.next().isBlockEnd()).isTrue();
+        assertThat(lexer.next().isEndOfInput()).isTrue();
+    }
+
+    @Test
+    void whitespaceNormalization() {
+        Lexer lexer = new Lexer("  print\n \"hello\"  ");
+        assertThat(lexer.next().isKeyword("print")).isTrue();
+        assertThat(lexer.next().expectLiteral()).isEqualTo("hello");
+        assertThat(lexer.next().isEndOfInput()).isTrue();
+    }
+
+    @Test
+    void tabRejection() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> new Lexer("  print\n\t\"hello\"  "))
+                .withMessageContaining("TAB characters are not allowed");
+    }
+
+    @Test
+    void unterminatedStringLiteral() {
+        Lexer lexer = new Lexer("\"unterminated");
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(lexer::next)
+                .withMessageContaining("unterminated string literal");
+    }
+
+    @Test
+    void illegalCharacter() {
+        Lexer lexer = new Lexer("$");
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(lexer::next)
+                .withMessageContaining("illegal character");
+    }
+
+    @Test
+    void expectLiteralFailure() {
+        Lexer lexer = new Lexer("print");
+        lexer.next();
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(lexer::expectLiteral)
+                .withMessageContaining("expected literal");
+    }
+}


### PR DESCRIPTION
Replaced the previous terse and cryptic BuildOption syntax with a new, more readable declarative DSL.  The new language improves clarity and structure, using a hierarchical block-based format with explicit keywords and quoted literals.

This change makes it easier for users to understand and maintain packaging configurations without consulting internal documentation.