### PR TITLE
Implement auto-formatter for declarative DSL

### DIFF
--- a/dola-dbs/src/main/java/io/kojan/dola/build/parser/BuildOptionFormater.java
+++ b/dola-dbs/src/main/java/io/kojan/dola/build/parser/BuildOptionFormater.java
@@ -1,0 +1,33 @@
+/*-
+ * Copyright (c) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kojan.dola.build.parser;
+
+import io.kojan.dola.build.DeclarativeBuildBuilder;
+
+public class BuildOptionFormater {
+    private final FormattingLexer lexer;
+    private final BuildOptionParser parser;
+
+    public BuildOptionFormater(String str) {
+        lexer = new FormattingLexer(str);
+        parser = new BuildOptionParser(lexer, new DeclarativeBuildBuilder("dummy"));
+    }
+
+    public String format() {
+        parser.parse();
+        return lexer.asString();
+    }
+}

--- a/dola-dbs/src/main/java/io/kojan/dola/build/parser/FormattingLexer.java
+++ b/dola-dbs/src/main/java/io/kojan/dola/build/parser/FormattingLexer.java
@@ -1,0 +1,78 @@
+/*-
+ * Copyright (c) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kojan.dola.build.parser;
+
+class FormattingLexer extends Lexer {
+    private int indentLevel;
+    private boolean whiteSpaceBefore;
+    private boolean newLineBefore;
+    private final StringBuilder buffer = new StringBuilder();
+    private String currentToken;
+
+    public FormattingLexer(String str) {
+        super(str);
+    }
+
+    private void token(String nextToken) {
+        if (currentToken != null) {
+            boolean newLineAfter;
+            if (currentToken.equals("{")) {
+                indentLevel++;
+                newLineAfter = true;
+            } else if (currentToken.equals("}")) {
+                indentLevel--;
+                newLineBefore = true;
+                newLineAfter = true;
+            } else {
+                newLineAfter = false;
+            }
+            if (whiteSpaceBefore) {
+                if (newLineBefore) {
+                    buffer.append('\n').append("  ".repeat(indentLevel));
+                } else {
+                    buffer.append(' ');
+                }
+            }
+            buffer.append(currentToken);
+            newLineBefore = newLineAfter;
+            whiteSpaceBefore = true;
+        }
+        currentToken = nextToken;
+    }
+
+    @Override
+    public Lexer next() {
+        super.next();
+        token(str.substring(lexBeg, lexEnd));
+        return this;
+    }
+
+    @Override
+    public boolean isBlockEnd() {
+        newLineBefore = true;
+        return super.isBlockEnd();
+    }
+
+    @Override
+    public boolean isEndOfInput() {
+        newLineBefore = true;
+        return super.isEndOfInput();
+    }
+
+    public String asString() {
+        return buffer.toString();
+    }
+}


### PR DESCRIPTION
Added support for formatting DSL input into a canonical, consistent form.  The formatter enforces standardized indentation, quoted literals, and block structure, improving readability and minimizing syntactic ambiguity.

This ensures a single authoritative representation of the DSL, useful for tooling, reviews, and version control diffs.