### PR TITLE
Fix NoSuchRealmException in BSX

### DIFF
--- a/dola-bsx/src/main/java/io/kojan/dola/bsx/BSX.java
+++ b/dola-bsx/src/main/java/io/kojan/dola/bsx/BSX.java
@@ -23,6 +23,7 @@ import java.util.TreeSet;
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.launcher.Configurator;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 
 public class BSX {
 
@@ -61,11 +62,13 @@ public class BSX {
         // XXX load org.objectweb.asm.ClassVisitor now
         // I don't know why, but loading it later from the same realm results in
         // ClassNotFoundException
-        ClassRealm cr = classWorld.getRealm("Realm:generator");
-        if (cr != null) {
+        try {
+            ClassRealm cr = classWorld.getRealm("Realm:generator");
             Thread.currentThread().setContextClassLoader(cr);
             cr.loadClassFromSelf("org.objectweb.asm.ClassVisitor");
             Thread.currentThread().setContextClassLoader(systemClassLoader);
+        } catch (NoSuchRealmException e) {
+            // Ignore
         }
         return "";
     }


### PR DESCRIPTION
BSX contains code to try to load ASM classes in advance from Realm:generator.  Previously it would crash with NoSuchRealmException when the realm was not present, i.e. when Dola BSX was used without Dola Generator installed.