### PR TITLE
Fix CNFE caused by ZLIB EOFException

### DIFF
--- a/dola-bsx/src/main/java/io/kojan/dola/bsx/BSX.java
+++ b/dola-bsx/src/main/java/io/kojan/dola/bsx/BSX.java
@@ -23,7 +23,6 @@ import java.util.TreeSet;
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.launcher.Configurator;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
-import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 
 public class BSX {
 
@@ -58,17 +57,6 @@ public class BSX {
             for (ClassRealm cr : classWorld.getRealms()) {
                 cr.display(System.err);
             }
-        }
-        // XXX load org.objectweb.asm.ClassVisitor now
-        // I don't know why, but loading it later from the same realm results in
-        // ClassNotFoundException
-        try {
-            ClassRealm cr = classWorld.getRealm("Realm:generator");
-            Thread.currentThread().setContextClassLoader(cr);
-            cr.loadClassFromSelf("org.objectweb.asm.ClassVisitor");
-            Thread.currentThread().setContextClassLoader(systemClassLoader);
-        } catch (NoSuchRealmException e) {
-            // Ignore
         }
         return "";
     }

--- a/dola-generator/src/main/conf/dola-generator.conf
+++ b/dola-generator/src/main/conf/dola-generator.conf
@@ -1,6 +1,5 @@
 [Realm:generator]
 import io.kojan.dola.rpm from Realm:bsx-api
-load /usr/share/java/dola/dola-generator.jar
 load /usr/share/java/objectweb-asm/asm.jar
 load /usr/share/java/commons-compress.jar
 load /usr/share/java/commons-io.jar
@@ -13,3 +12,4 @@ load /usr/share/java/maven4/maven-api-xml-4.0.0-rc-3.jar
 load /usr/share/java/maven4/maven-xml-4.0.0-rc-3.jar
 load /usr/share/java/maven4/maven-support-4.0.0-rc-3.jar
 load /usr/share/java/plexus-utils4/plexus-utils-4.0.2.jar
+load /usr/share/java/dola/dola-generator.jar


### PR DESCRIPTION
In an embedded JVM setup with JVM running inside rpmbuild process, invoked via JNI, Dola Generator intermittently failed to load ASM classes such as `org.objectweb.asm.ClassVisitor`, even though `asm.jar` was correctly included in the ClassRealm (class loader).

The exception appeared as:

    java.lang.ClassNotFoundException: org.objectweb.asm.ClassVisitor

However, the actual underlying cause (not visible initially due to Plexus Classworlds catching and re-throwing the CNFE exception without preserving its cause) was:

    java.io.EOFException: Unexpected end of ZLIB input stream

Detailed debugging (using tools like `strace` and inspecting class loader internals) showed the following sequence clearly:

- On the first JNI call to Dola Generator, the JVM loaded classes exclusively from `dola-generator.jar`.  `asm.jar` was never opened or touched during this call, as no ASM classes were required yet.

- On a subsequent JNI call, ASM classes became required.  When loading `ClassVisitor`, the JVM attempted to locate it first in the earliest JAR in the ClassRealm's URL list, which was `dola-generator.jar`.

- At this point, JVM internal ZIP handling attempted to access or parse entries from `dola-generator.jar`, but the underlying ZIP stream or file descriptor had become invalid (closed or corrupted at the native OS level, not sure exactly how this happened). This triggered the ZLIB EOFException, causing the search to fail prematurely.  As a result, `asm.jar` was never even opened during this second call, and CNFE was thrown caused by EOFException.

The root issue was thus the lazy ZIP parsing of the first JAR, combined with file descriptor or stream invalidation occurring between JNI calls.  This manifested indirectly as a class resolution failure.

The solution is straightforward but non-obvious: move `dola-generator.jar` to the end of the ClassRealm URL list. When the JVM later attempts to load `ClassVisitor`, `asm.jar` has already been opened and fully read during an earlier JNI call. As a result, the JVM no longer needs to inspect or parse the problematic ZIP streams, completely avoiding the error condition.