### PR TITLE
Allow override of classworlds configuration directory

### DIFF
--- a/dola-bsx/src/main/lua/dola-bsx.lua
+++ b/dola-bsx/src/main/lua/dola-bsx.lua
@@ -18,7 +18,7 @@ local lujavrite = require "lujavrite"
 
 local libjvm = rpm.expand("%{__dola_libjvm}")
 local classpath = rpm.expand("%{__dola_classpath}")
-local classworlds_conf = rpm.expand("%{_javaconfdir}/dola/classworlds")
+local classworlds_conf = rpm.expand("%{__dola_classworlds}")
 
 -- Initialize JVM
 if not lujavrite.initialized() then

--- a/dola-bsx/src/main/rpm/macros.dola-bsx
+++ b/dola-bsx/src/main/rpm/macros.dola-bsx
@@ -3,3 +3,6 @@
 
 # Class path of nested JVM.
 %__dola_classpath %{_javadir}/dola/dola-bsx.jar:%{_javadir}/plexus-classworlds.jar
+
+# Path to configuration directory
+%__dola_classworlds %{_javaconfdir}/dola/classworlds


### PR DESCRIPTION
This is necessary for Fedora flatpaks, as components needed by apps at runtime are built in /app (thereby affecting %_javaconfdir), but dola is only used at build time to generate dependencies and provides.

This will need to be backported to at least F44 in order to fix Fedora flatpak builds of Java libraries needed for a number of aps.

Resolves: rhbz#2402661